### PR TITLE
fix timezone for container based on openjdk-8:slim

### DIFF
--- a/satori/images/alarm/Dockerfile.tpl
+++ b/satori/images/alarm/Dockerfile.tpl
@@ -2,8 +2,7 @@ FROM USE_MIRRORopenjdk:8-slim
 MAINTAINER feisuzhu@163.com
 
 ENV TERM xterm
-RUN echo "Asia/Shanghai" | tee /etc/timezone
-RUN dpkg-reconfigure --frontend noninteractive tzdata
+RUN rm -f /etc/localtime && ln -s /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 RUN adduser ubuntu
 RUN [ -z "USE_MIRROR" ] || sed -E -i 's/(deb|security).debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y curl nginx fcgiwrap supervisor git python redis-server

--- a/satori/images/grafana/Dockerfile.tpl
+++ b/satori/images/grafana/Dockerfile.tpl
@@ -2,8 +2,7 @@ FROM USE_MIRRORopenjdk:8-slim
 MAINTAINER feisuzhu@163.com
 
 ENV TERM xterm
-RUN echo "Asia/Shanghai" | tee /etc/timezone
-RUN dpkg-reconfigure --frontend noninteractive tzdata
+RUN rm -f /etc/localtime && ln -s /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 RUN adduser ubuntu
 RUN [ -z "USE_MIRROR" ] || sed -E -i 's/(deb|security).debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y curl nginx fcgiwrap supervisor git python redis-server

--- a/satori/images/influxdb/Dockerfile.tpl
+++ b/satori/images/influxdb/Dockerfile.tpl
@@ -2,8 +2,7 @@ FROM USE_MIRRORopenjdk:8-slim
 MAINTAINER feisuzhu@163.com
 
 ENV TERM xterm
-RUN echo "Asia/Shanghai" | tee /etc/timezone
-RUN dpkg-reconfigure --frontend noninteractive tzdata
+RUN rm -f /etc/localtime && ln -s /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 RUN adduser ubuntu
 RUN [ -z "USE_MIRROR" ] || sed -E -i 's/(deb|security).debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y curl nginx fcgiwrap supervisor git python redis-server

--- a/satori/images/master/Dockerfile.tpl
+++ b/satori/images/master/Dockerfile.tpl
@@ -2,8 +2,7 @@ FROM USE_MIRRORopenjdk:8-slim
 MAINTAINER feisuzhu@163.com
 
 ENV TERM xterm
-RUN echo "Asia/Shanghai" | tee /etc/timezone
-RUN dpkg-reconfigure --frontend noninteractive tzdata
+RUN rm -f /etc/localtime && ln -s /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 RUN adduser ubuntu
 RUN [ -z "USE_MIRROR" ] || sed -E -i 's/(deb|security).debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y curl nginx fcgiwrap supervisor git python redis-server

--- a/satori/images/nginx/Dockerfile.tpl
+++ b/satori/images/nginx/Dockerfile.tpl
@@ -2,8 +2,7 @@ FROM USE_MIRRORopenjdk:8-slim
 MAINTAINER feisuzhu@163.com
 
 ENV TERM xterm
-RUN echo "Asia/Shanghai" | tee /etc/timezone
-RUN dpkg-reconfigure --frontend noninteractive tzdata
+RUN rm -f /etc/localtime && ln -s /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 RUN adduser ubuntu
 RUN [ -z "USE_MIRROR" ] || sed -E -i 's/(deb|security).debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y curl nginx fcgiwrap supervisor git python redis-server

--- a/satori/images/redis/Dockerfile.tpl
+++ b/satori/images/redis/Dockerfile.tpl
@@ -2,8 +2,7 @@ FROM USE_MIRRORopenjdk:8-slim
 MAINTAINER feisuzhu@163.com
 
 ENV TERM xterm
-RUN echo "Asia/Shanghai" | tee /etc/timezone
-RUN dpkg-reconfigure --frontend noninteractive tzdata
+RUN rm -f /etc/localtime && ln -s /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 RUN adduser ubuntu
 RUN [ -z "USE_MIRROR" ] || sed -E -i 's/(deb|security).debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y curl nginx fcgiwrap supervisor git python redis-server

--- a/satori/images/riemann/Dockerfile.tpl
+++ b/satori/images/riemann/Dockerfile.tpl
@@ -2,8 +2,7 @@ FROM USE_MIRRORopenjdk:8-slim
 MAINTAINER feisuzhu@163.com
 
 ENV TERM xterm
-RUN echo "Asia/Shanghai" | tee /etc/timezone
-RUN dpkg-reconfigure --frontend noninteractive tzdata
+RUN rm -f /etc/localtime && ln -s /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 RUN adduser ubuntu
 RUN [ -z "USE_MIRROR" ] || sed -E -i 's/(deb|security).debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y curl nginx fcgiwrap supervisor git python redis-server

--- a/satori/images/transfer/Dockerfile.tpl
+++ b/satori/images/transfer/Dockerfile.tpl
@@ -2,8 +2,7 @@ FROM USE_MIRRORopenjdk:8-slim
 MAINTAINER feisuzhu@163.com
 
 ENV TERM xterm
-RUN echo "Asia/Shanghai" | tee /etc/timezone
-RUN dpkg-reconfigure --frontend noninteractive tzdata
+RUN rm -f /etc/localtime && ln -s /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 RUN adduser ubuntu
 RUN [ -z "USE_MIRROR" ] || sed -E -i 's/(deb|security).debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y curl nginx fcgiwrap supervisor git python redis-server


### PR DESCRIPTION
如题，貌似是 dpkg-reconfigure --frontend noninteractive tzdata 这个会重写 /etc/timezone