### PR TITLE
quartz

### DIFF
--- a/agent/funcs/cpustat.go
+++ b/agent/funcs/cpustat.go
@@ -157,7 +157,7 @@ func CpuMetrics() []*model.MetricValue {
 	cpuIdleVal := CpuIdle()
 	cpuIowaitVal := CpuIowait()
 	idle := V("cpu.idle", cpuIdleVal)
-	idle := V("cpu.free", cpuIdleVal+cpuIoWaitVal)
+	free := V("cpu.free", cpuIdleVal+cpuIowaitVal)
 	busy := V("cpu.busy", 100.0-cpuIdleVal)
 	user := V("cpu.user", CpuUser())
 	nice := V("cpu.nice", CpuNice())
@@ -168,5 +168,5 @@ func CpuMetrics() []*model.MetricValue {
 	steal := V("cpu.steal", CpuSteal())
 	guest := V("cpu.guest", CpuGuest())
 	switches := V("cpu.switches", float64(CurrentCpuSwitches()))
-	return []*model.MetricValue{idle, busy, user, nice, system, iowait, irq, softirq, steal, guest, switches}
+	return []*model.MetricValue{idle, free, busy, user, nice, system, iowait, irq, softirq, steal, guest, switches}
 }

--- a/satori/images/riemann/Dockerfile
+++ b/satori/images/riemann/Dockerfile
@@ -3,4 +3,5 @@ FROM satori:base
 WORKDIR /tmp
 EXPOSE 5555
 ADD app /app
+RUN curl http://lc-paas-files.cn-n1.lcfile.com/riemann-0.3.3-satori-standalone.jar -o /app/riemann.jar
 CMD ["/app/bootstrap.sh"]

--- a/satori/images/riemann/Dockerfile
+++ b/satori/images/riemann/Dockerfile
@@ -3,5 +3,4 @@ FROM satori:base
 WORKDIR /tmp
 EXPOSE 5555
 ADD app /app
-RUN curl http://satori.thb.io/riemann-0.3.3-satori-standalone.jar -o /app/riemann.jar
 CMD ["/app/bootstrap.sh"]

--- a/satori/images/riemann/build-jar.sh
+++ b/satori/images/riemann/build-jar.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# require lein+jdk
+
+lein uberjar && \
+  cp target/riemann-*-satori-standalone.jar app/

--- a/satori/images/riemann/build-jar.sh
+++ b/satori/images/riemann/build-jar.sh
@@ -3,4 +3,4 @@
 # require lein+jdk
 
 lein uberjar && \
-  cp target/riemann-*-satori-standalone.jar app/
+  cp target/riemann-*-satori-standalone.jar app/riemann.jar

--- a/satori/images/riemann/project.clj
+++ b/satori/images/riemann/project.clj
@@ -10,5 +10,6 @@
                  [org.clojure/core.match "0.3.0"]
                  [org.clojure/core.async "0.4.490"]
                  [com.taoensso/carmine "2.19.1"]
+                 [org.quartz-scheduler/quartz "2.3.0" :exclusions [org.slf4j/slf4j-api]]
                  [io.aviso/pretty "0.1.37"]
                  [riemann "0.3.2"]])


### PR DESCRIPTION
添加依赖 quartz , 在 rules 中可以使用 CronExpression 来实现报警静默的功能

添加 quiet? 函数，来按规则来过滤掉某些时间段内的报警信息。
过滤规则如：`[['backup','* * 1-9 * * ?']]`
* backup 是个正则（也可以为 string), 用来匹配 host(endpoint)
* '* * 1-9 * * ?' 为 cron 的表达式(local timezone)，用来表示生效的时间范围"